### PR TITLE
fix: CI test runner consistency

### DIFF
--- a/src/tests/integration/codeAction.test.ts
+++ b/src/tests/integration/codeAction.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert";
 import * as vscode from "vscode";
 
 describe("Code Actions", function () {
-  this.timeout(5000);
+  this.timeout(7000);
 
   const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   assert.ok(workspace, "No workspace found");

--- a/src/tests/integration/comment.test.ts
+++ b/src/tests/integration/comment.test.ts
@@ -4,6 +4,8 @@ import assert from "node:assert";
 import * as vscode from "vscode";
 
 describe("Comment Scanning", function () {
+  this.timeout(4000);
+
   const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   assert.ok(workspace, "No workspace found");
 

--- a/src/tests/integration/path.test.ts
+++ b/src/tests/integration/path.test.ts
@@ -4,6 +4,8 @@ import assert from "node:assert";
 import * as vscode from "vscode";
 
 describe("File Path Scanning", function () {
+  this.timeout(4000);
+
   const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   assert.ok(workspace, "No workspace found");
 

--- a/src/tests/integration/secret.test.ts
+++ b/src/tests/integration/secret.test.ts
@@ -6,6 +6,8 @@ import assert from "node:assert";
 import * as vscode from "vscode";
 
 describe("Secret Scanning", function () {
+  this.timeout(4000);
+
   const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   assert.ok(workspace, "No workspace found");
 

--- a/src/tests/integration/utils.ts
+++ b/src/tests/integration/utils.ts
@@ -50,10 +50,10 @@ export const redkitten6sSupabaseKey =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZlbG1qa2VxZWttaGt4c3JycndiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njg1NzE4NTksImV4cCI6MjA4NDE0Nzg1OX0.cbspqjrqcdDkREd3tOlS2TcjknjIzUUeIcX_t8eNYfE";
 export const redkitten6sYouTubeKey = "AIzaSyAVQKyYxMrhgHWR8f9LJms0GVpcufhMLwc";
 
-export function resetConfig() {
-  vscode.workspace.getConfiguration("gitgerbil").update("scannedFileTypes", defaultScannedFiles, vscode.ConfigurationTarget.Global);
-  vscode.workspace.getConfiguration("gitgerbil").update("enableFilePathScanning", true, vscode.ConfigurationTarget.Global);
-  vscode.workspace.getConfiguration("gitgerbil").update("enableSecretScanning", true, vscode.ConfigurationTarget.Global);
-  vscode.workspace.getConfiguration("gitgerbil").update("enableStrictSecretScanning", true, vscode.ConfigurationTarget.Global);
-  vscode.workspace.getConfiguration("gitgerbil").update("enableCommentScanning", true, vscode.ConfigurationTarget.Global);
+export async function resetConfig() {
+  await vscode.workspace.getConfiguration("gitgerbil").update("scannedFileTypes", defaultScannedFiles, vscode.ConfigurationTarget.Global);
+  await vscode.workspace.getConfiguration("gitgerbil").update("enableFilePathScanning", true, vscode.ConfigurationTarget.Global);
+  await vscode.workspace.getConfiguration("gitgerbil").update("enableSecretScanning", true, vscode.ConfigurationTarget.Global);
+  await vscode.workspace.getConfiguration("gitgerbil").update("enableStrictSecretScanning", true, vscode.ConfigurationTarget.Global);
+  await vscode.workspace.getConfiguration("gitgerbil").update("enableCommentScanning", true, vscode.ConfigurationTarget.Global);
 }


### PR DESCRIPTION
each suite's afterEach function (`resetConfig()`) now waits for the config settings to update